### PR TITLE
feat: HTTP/HTTPS flexible mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,20 +88,29 @@ applications. To enable this, add the `--tls` flag when deploying an instance:
 
     kamal-proxy deploy service1 --target web-1:3000 --host app1.example.com --tls
 
-
 ### On-demand TLS
 
-In addition of the automatic TLS functionality, Kamal Proxy can also dynamically obtain a TLS certificate 
+In addition of the automatic TLS functionality, Kamal Proxy can also dynamically obtain a TLS certificate
 from any host allowed by an external API endpoint of your choice.
 This avoids hard-coding hosts in the configuration, especially when you don't know the hosts at the startup.
 
     kamal-proxy deploy service1 --target web-1:3000 --host "" --tls --tls-on-demand-url="http://localhost:4567/check"
 
-The On-demand URL endpoint will have to answer a 200 HTTP status code. 
+The On-demand URL endpoint will have to answer a 200 HTTP status code.
 Kamal Proxy will call the on-demand URL with a query string of `?host=` containing the host received by Kamal Proxy.
 
 It also must respond as fast as possible, a couple of milliseconds top.
 
+### TLS Flexible mode
+
+The On-demand TLS feature offers a TLS certificate for any dynamic host.
+However, some hosts can be served by Cloudflare, and in that case, Kamal Proxy is unable to generate a TLS certificate.
+
+Unless you provide a custom TLS certificate for those hosts, a quick solution is to allow a non-secure connection between Cloudflare and Kamal Proxy ("flexible" mode in Cloudflare). On the Kamal Proxy side, we need to accept non-secure connections and not redirect them to HTTPS.
+
+    kamal-proxy deploy service1 --target web-1:3000 --host "" --tls --tls-on-demand-url="http://localhost:4567/check" --tls-flexible-mode=true
+
+In return, the application handling the requests from Kamal Proxy must be in charge of redirecting HTTP connections to HTTPS.
 
 ### Custom TLS certificate
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ In addition of the automatic TLS functionality, Kamal Proxy can also dynamically
 from any host allowed by an external API endpoint of your choice.
 This avoids hard-coding hosts in the configuration, especially when you don't know the hosts at the startup.
 
-    kamal-proxy deploy service1 --target web-1:3000 --host "" --tls --tls-on-demand-url=localhost:4567/check
+    kamal-proxy deploy service1 --target web-1:3000 --host "" --tls --tls-on-demand-url="http://localhost:4567/check"
 
 The On-demand URL endpoint will have to answer a 200 HTTP status code. 
 Kamal Proxy will call the on-demand URL with a query string of `?host=` containing the host received by Kamal Proxy.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ applications. To enable this, add the `--tls` flag when deploying an instance:
     kamal-proxy deploy service1 --target web-1:3000 --host app1.example.com --tls
 
 
-## On-demand TLS
+### On-demand TLS
 
 In addition of the automatic TLS functionality, Kamal Proxy can also dynamically obtain a TLS certificate 
 from any host allowed by an external API endpoint of your choice.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ applications. To enable this, add the `--tls` flag when deploying an instance:
     kamal-proxy deploy service1 --target web-1:3000 --host app1.example.com --tls
 
 
+## On-demand TLS
+
+In addition of the automatic TLS functionality, Kamal Proxy can also dynamically obtain a TLS certificate 
+from any host allowed by an external API endpoint of your choice.
+This avoids hard-coding hosts in the configuration, especially when you don't know the hosts at the startup.
+
+    kamal-proxy deploy service1 --target web-1:3000 --host "" --tls --tls-on-demand-url=localhost:4567/check
+
+The On-demand URL endpoint will have to answer a 200 HTTP status code. 
+Kamal Proxy will call the on-demand URL with a query string of `?host=` containing the host received by Kamal Proxy.
+
+It also must respond as fast as possible, a couple of milliseconds top.
+
+
 ### Custom TLS certificate
 
 When you obtained your TLS certificate manually, manage your own certificate authority,

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -30,6 +30,7 @@ func newDeployCommand() *deployCommand {
 	deployCommand.cmd.Flags().StringSliceVar(&deployCommand.args.Hosts, "host", []string{}, "Host(s) to serve this target on (empty for wildcard)")
 
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.TLSEnabled, "tls", false, "Configure TLS for this target (requires a non-empty host)")
+	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSOnDemandUrl, "tls-on-demand-url", "", "Will make an HTTP request to the given URL, asking whether a host is allowed to have a certificate issued.")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.tlsStaging, "tls-staging", false, "Use Let's Encrypt staging environment for certificate provisioning")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSCertificatePath, "tls-certificate-path", "", "Configure custom TLS certificate path (PEM format)")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSPrivateKeyPath, "tls-private-key-path", "", "Configure custom TLS private key path (PEM format)")

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -31,6 +31,7 @@ func newDeployCommand() *deployCommand {
 
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.TLSEnabled, "tls", false, "Configure TLS for this target (requires a non-empty host)")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSOnDemandUrl, "tls-on-demand-url", "", "Will make an HTTP request to the given URL, asking whether a host is allowed to have a certificate issued.")
+	deployCommand.cmd.Flags().BoolVar(&deployCommand.args.ServiceOptions.TLSFlexibleMode, "tls-flexible-mode", false, "Allow Kamal proxy to be flexible (accept both HTTP and HTTPS traffic)")
 	deployCommand.cmd.Flags().BoolVar(&deployCommand.tlsStaging, "tls-staging", false, "Use Let's Encrypt staging environment for certificate provisioning")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSCertificatePath, "tls-certificate-path", "", "Configure custom TLS certificate path (PEM format)")
 	deployCommand.cmd.Flags().StringVar(&deployCommand.args.ServiceOptions.TLSPrivateKeyPath, "tls-private-key-path", "", "Configure custom TLS private key path (PEM format)")

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -72,6 +72,7 @@ type ServiceOptions struct {
 	TLSOnDemandUrl     string `json:"tls_on_demand_url"`
 	TLSCertificatePath string `json:"tls_certificate_path"`
 	TLSPrivateKeyPath  string `json:"tls_private_key_path"`
+	TLSFlexibleMode 	 bool 	`json:"tls_flexible_mode"`
 	ACMEDirectory      string `json:"acme_directory"`
 	ACMECachePath      string `json:"acme_cache_path"`
 	ErrorPagePath      string `json:"error_page_path"`
@@ -395,7 +396,7 @@ func (s *Service) createMiddleware(options ServiceOptions, certManager CertManag
 func (s *Service) serviceRequestWithTarget(w http.ResponseWriter, r *http.Request) {
 	LoggingRequestContext(r).Service = s.name
 
-	if s.options.TLSEnabled && r.TLS == nil {
+	if s.options.TLSEnabled && s.options.TLSFlexibleMode == false && r.TLS == nil {
 		s.redirectToHTTPS(w, r)
 		return
 	}

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -1,13 +1,16 @@
 package server
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -66,6 +69,7 @@ type HealthCheckConfig struct {
 
 type ServiceOptions struct {
 	TLSEnabled         bool   `json:"tls_enabled"`
+	TLSOnDemandUrl     string `json:"tls_on_demand_url"`
 	TLSCertificatePath string `json:"tls_certificate_path"`
 	TLSPrivateKeyPath  string `json:"tls_private_key_path"`
 	ACMEDirectory      string `json:"acme_directory"`
@@ -313,16 +317,83 @@ func (s *Service) createCertManager(hosts []string, options ServiceOptions) (Cer
 	// Ensure we're not trying to use Let's Encrypt to fetch a wildcard domain,
 	// as that is not supported with the challenge types that we use.
 	for _, host := range hosts {
-		if strings.Contains(host, "*") {
+		if strings.Contains(host, "*") && options.TLSOnDemandUrl == "" {
 			return nil, ErrorAutomaticTLSDoesNotSupportWildcards
 		}
+	}
+
+	// // TODO:
+	// // - create a func instead to return the host policy
+	// // - create the function calling the on demand url
+	// var hostPolicy = autocert.HostWhitelist(hosts...)
+
+	// // https://stackoverflow.com/questions/52129908/can-i-have-a-dynamic-host-policty-with-autocert
+
+	// // Wildcard hosts!!! we can handle them now!
+	// if len(hosts) == 0 && options.TLSOnDemandUrl != "" {
+	// 	fmt.Println("🚀🚀🚀 Registering a custom hostPolicy for", hosts)
+	// 	hostPolicy = func(ctx context.Context, host string) error {
+	// 		slog.Debug("Contacting", options.TLSOnDemandUrl, host)
+
+	// 		resp, err := http.Get(fmt.Sprintf("%s?domain=%s", options.TLSOnDemandUrl, url.QueryEscape(host)))
+
+	// 		if err != nil {
+	// 			// the TLS on demand URL is not reachable
+	// 			slog.Error("Unable to reach the TLS on demand URL", host, err)
+	// 			return err
+	// 		}
+
+	// 		if resp.StatusCode != 200 && resp.StatusCode != 201 {
+	// 			return fmt.Errorf("%s is not allowed to get a certificate", host)
+	// 		}
+
+	// 		return nil
+	// 	}
+	// } else {
+	// 	fmt.Println("😕😕😕", len(hosts), hosts, options.TLSOnDemandUrl)
+	// }
+
+	hostPolicy, err := s.createAutoCertHostPolicy(hosts, options)
+
+	if err != nil {
+		return nil, err
 	}
 
 	return &autocert.Manager{
 		Prompt:     autocert.AcceptTOS,
 		Cache:      autocert.DirCache(options.ScopedCachePath()),
-		HostPolicy: autocert.HostWhitelist(hosts...),
+		HostPolicy: hostPolicy,
 		Client:     &acme.Client{DirectoryURL: options.ACMEDirectory},
+	}, nil
+}
+
+func (s *Service) createAutoCertHostPolicy(hosts []string, options ServiceOptions) (autocert.HostPolicy, error) {
+	onDemandTls := len(hosts) == 0 && options.TLSOnDemandUrl != ""
+
+	if !onDemandTls {
+		return autocert.HostWhitelist(hosts...), nil
+	}
+
+	_, err := url.ParseRequestURI(options.TLSOnDemandUrl)
+
+	if err != nil {
+		slog.Error("Unable to parse the tls_on_demand_url URL")
+		return nil, err
+	}
+
+	return func(ctx context.Context, host string) error {
+		resp, err := http.Get(fmt.Sprintf("%s?host=%s", options.TLSOnDemandUrl, url.QueryEscape(host)))
+
+		if err != nil {
+			slog.Error("Unable to reach the TLS on demand URL", host, err)
+			return err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("%s is not allowed to get a certificate", host)
+		}
+
+		return nil
 	}, nil
 }
 

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -337,9 +337,9 @@ func (s *Service) createCertManager(hosts []string, options ServiceOptions) (Cer
 }
 
 func (s *Service) createAutoCertHostPolicy(hosts []string, options ServiceOptions) (autocert.HostPolicy, error) {
-	onDemandTls := len(hosts) == 0 && options.TLSOnDemandUrl != ""
+	slog.Info("createAutoCertHostPolicy called", options.TLSOnDemandUrl, len(hosts), "🚨", "ok")
 
-	if !onDemandTls {
+	if options.TLSOnDemandUrl == "" {
 		return autocert.HostWhitelist(hosts...), nil
 	}
 
@@ -350,7 +350,11 @@ func (s *Service) createAutoCertHostPolicy(hosts []string, options ServiceOption
 		return nil, err
 	}
 
+	slog.Info("Will use the tls_on_demand_url URL")
+
 	return func(ctx context.Context, host string) error {
+		slog.Info("Get a certificate for", host, "🤞")
+
 		resp, err := http.Get(fmt.Sprintf("%s?host=%s", options.TLSOnDemandUrl, url.QueryEscape(host)))
 
 		if err != nil {

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -317,7 +317,7 @@ func (s *Service) createCertManager(hosts []string, options ServiceOptions) (Cer
 	// Ensure we're not trying to use Let's Encrypt to fetch a wildcard domain,
 	// as that is not supported with the challenge types that we use.
 	for _, host := range hosts {
-		if strings.Contains(host, "*") && options.TLSOnDemandUrl == "" {
+		if strings.Contains(host, "*") {
 			return nil, ErrorAutomaticTLSDoesNotSupportWildcards
 		}
 	}

--- a/internal/server/service.go
+++ b/internal/server/service.go
@@ -322,37 +322,6 @@ func (s *Service) createCertManager(hosts []string, options ServiceOptions) (Cer
 		}
 	}
 
-	// // TODO:
-	// // - create a func instead to return the host policy
-	// // - create the function calling the on demand url
-	// var hostPolicy = autocert.HostWhitelist(hosts...)
-
-	// // https://stackoverflow.com/questions/52129908/can-i-have-a-dynamic-host-policty-with-autocert
-
-	// // Wildcard hosts!!! we can handle them now!
-	// if len(hosts) == 0 && options.TLSOnDemandUrl != "" {
-	// 	fmt.Println("🚀🚀🚀 Registering a custom hostPolicy for", hosts)
-	// 	hostPolicy = func(ctx context.Context, host string) error {
-	// 		slog.Debug("Contacting", options.TLSOnDemandUrl, host)
-
-	// 		resp, err := http.Get(fmt.Sprintf("%s?domain=%s", options.TLSOnDemandUrl, url.QueryEscape(host)))
-
-	// 		if err != nil {
-	// 			// the TLS on demand URL is not reachable
-	// 			slog.Error("Unable to reach the TLS on demand URL", host, err)
-	// 			return err
-	// 		}
-
-	// 		if resp.StatusCode != 200 && resp.StatusCode != 201 {
-	// 			return fmt.Errorf("%s is not allowed to get a certificate", host)
-	// 		}
-
-	// 		return nil
-	// 	}
-	// } else {
-	// 	fmt.Println("😕😕😕", len(hosts), hosts, options.TLSOnDemandUrl)
-	// }
-
 	hostPolicy, err := s.createAutoCertHostPolicy(hosts, options)
 
 	if err != nil {


### PR DESCRIPTION
## TLS Flexible mode

The On-demand TLS feature offers a TLS certificate for any dynamic host.
However, some hosts can be served by Cloudflare, and in that case, Kamal Proxy is unable to generate a TLS certificate.

Unless you provide a custom TLS certificate for those hosts, a quick solution is to allow a non-secure connection between Cloudflare and Kamal Proxy ("flexible" mode in Cloudflare). On the Kamal Proxy side, we need to accept non-secure connections and not redirect them to HTTPS.

```bash
    kamal-proxy deploy service1 --target web-1:3000 --host "" --tls --tls-on-demand-url="http://localhost:4567/check" --tls-flexible-mode=true
```

In return, the application handling the requests from Kamal Proxy must be in charge of redirecting HTTP connections to HTTPS.